### PR TITLE
rework how FakeCap `run` method works

### DIFF
--- a/lib/cap-util/fake_cap.rb
+++ b/lib/cap-util/fake_cap.rb
@@ -19,8 +19,8 @@ module CapUtil
       @struct.respond_to?(method) ? true : super
     end
 
-    def run(*args)
-      @cmds_run << args
+    def run(cmd, *args)
+      @cmds_run << cmd
     end
 
     def fetch(var_name)

--- a/test/fake_cap_tests.rb
+++ b/test/fake_cap_tests.rb
@@ -15,14 +15,11 @@ module CapUtil
     should have_imeths :run, :fetch, :role
     should have_readers :roles, :cmds_run
 
-    should "store off args to run cmd calls" do
+    should "store off cmds that have been run" do
       assert_empty subject.cmds_run
 
-      subject.run(:a, 1)
-      assert_equal [:a, 1], subject.cmds_run.last
-
-      subject.run
-      assert_equal [], subject.cmds_run.last
+      subject.run('a_cmd', 1)
+      assert_equal 'a_cmd', subject.cmds_run.last
     end
 
   end

--- a/test/rake_task_tests.rb
+++ b/test/rake_task_tests.rb
@@ -49,7 +49,7 @@ module CapUtil
       exp_cmd = "cd /a/current/path &&  bundle exec rake a:task:to:run"
       subject.run
 
-      assert_equal [exp_cmd], @fake_cap.cmds_run.last
+      assert_equal exp_cmd, @fake_cap.cmds_run.last
     end
 
   end

--- a/test/shared_path_tests.rb
+++ b/test/shared_path_tests.rb
@@ -22,7 +22,7 @@ module CapUtil
       subject.rm_rf 'cached-copy'
       exp_cmd = "rm -rf #{File.expand_path("tmp/shared/cached-copy")}"
 
-      assert_equal [exp_cmd], @fake_cap.cmds_run.last
+      assert_equal exp_cmd, @fake_cap.cmds_run.last
     end
 
   end


### PR DESCRIPTION
It now stores off just the first arg passed to it (the cmd) instead
of storing off all arguments in an array.  This has proven to be the
more intuitive default behavior for tracking run calls.
