### PR TITLE
Silence the `say` methods by setting ENV var

### DIFF
--- a/lib/cap-util/say.rb
+++ b/lib/cap-util/say.rb
@@ -7,11 +7,11 @@ module CapUtil
   end
 
   def self.say(msg, *args)
-    Capistrano::CLI.ui.say("    #{msg}", *args)
+    say_raw("    #{msg}", *args)
   end
 
   def self.say_bulleted(msg, *args)
-    Capistrano::CLI.ui.say("  * #{msg}", *args)
+    say_raw("  * #{msg}", *args)
   end
 
   def self.say_error(msg, *args)
@@ -20,6 +20,10 @@ module CapUtil
 
   def self.say_warning(msg, *args)
     say("#{color "[WARN]", :bold, :yellow} #{msg}", *args)
+  end
+
+  def self.say_raw(msg, *args)
+    Capistrano::CLI.ui.say(msg, *args) if !ENV['CAPUTIL_SILENCE_SAY']
   end
 
   module Say

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 # this file is automatically required in when you require 'assert' in your tests
 # put test helpers here
+ENV['CAPUTIL_SILENCE_SAY'] = 'yes'
 
 # add root dir to the load path
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))


### PR DESCRIPTION
This allows "silencing" the `say` methods by simply setting the
ENV var `CAPUTIL_SILENCE_SAY`. This is useful for test suites so
you don't get these message printed out while your tests are run.

Closes #3
