### PR TITLE
Provide `sudo` run method helper and support with `FakeCap`

### DIFF
--- a/lib/cap-util/fake_cap.rb
+++ b/lib/cap-util/fake_cap.rb
@@ -23,6 +23,10 @@ module CapUtil
       @cmds_run << cmd
     end
 
+    def sudo(cmd, *args)
+      run("sudo #{cmd}", *args)
+    end
+
     def fetch(var_name)
       self.send("fetch_#{var_name}")
     end

--- a/lib/cap-util/run.rb
+++ b/lib/cap-util/run.rb
@@ -59,6 +59,10 @@ module CapUtil
         run_as(user, cmd_str, opts) {|ch, stream, out| ch.send_data(input + "\n")}
       end
 
+      def sudo(*args, &block)
+        cap.sudo(*args, &block)
+      end
+
     end
 
   end

--- a/test/cap_util_tests.rb
+++ b/test/cap_util_tests.rb
@@ -41,6 +41,7 @@ module CapUtil
     should have_cmeths :run_locally, :run_locally_with_stdin
     should have_imeths :run_locally, :run_locally_with_stdin
     should have_imeths :run, :run_with_stdin, :run_as, :run_as_with_stdin
+    should have_imeths :sudo
 
     should have_cmeth :time
     should have_imeth :time

--- a/test/fake_cap_tests.rb
+++ b/test/fake_cap_tests.rb
@@ -12,7 +12,7 @@ module CapUtil
     subject { @fc }
 
     should have_imeths :method_missing, :respond_to?
-    should have_imeths :run, :fetch, :role
+    should have_imeths :run, :sudo, :fetch, :role
     should have_readers :roles, :cmds_run
 
     should "store off cmds that have been run" do
@@ -20,6 +20,9 @@ module CapUtil
 
       subject.run('a_cmd', 1)
       assert_equal 'a_cmd', subject.cmds_run.last
+
+      subject.sudo('a_cmd', 1)
+      assert_equal 'sudo a_cmd', subject.cmds_run.last
     end
 
   end


### PR DESCRIPTION
This provides a `sudo` run method (like regular `run`) so it
doesn't have to be called on the cap instance directly. This also
supports the `sudo` method with `FakeCap`. It will store it like
`run` does, but will prepend "sudo". This matches with how you
would normally write the command and allows finding them in the
`cmds_run` collection.

Closes #4
