### PR TITLE
get test suite passing in modern ruby versions

### DIFF
--- a/cap-util.gemspec
+++ b/cap-util.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.0"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("scmd",       ["~> 3.0.0"])
+  gem.add_dependency("scmd",       ["~> 3.0.2"])
   gem.add_dependency("capistrano", ["~> 2.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,15 @@ require 'pry'
 
 require 'test/support/factory'
 
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end
+
 ENV['CAPUTIL_SILENCE_SAY'] = 'yes'
 
 require 'cap-util'

--- a/test/unit/server_roles_tests.rb
+++ b/test/unit/server_roles_tests.rb
@@ -104,7 +104,7 @@ YAML
     end
 
     should "build its options with both string and symbol keys" do
-      server = CapUtil::ServerRoles::ServerDef.new('opts1', 'primary')
+      server = CapUtil::ServerRoles::ServerDef.new('opts1', ['primary'])
 
       assert_equal true, server.options[:primary]
       assert_equal true, server.options['primary']


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest patches
(which also now work in modern ruby versions) and updates the test
suite to get things passing in modern ruby versions. This also
brings in the Array#sample backfill for 1.8.7 compatibility.

@jcredding ready for review.
